### PR TITLE
Fix region name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ resources:
   source:
     bucket: bbl-state
     iaas: gcp
-    gcp_region: us-east-1
+    gcp_region: us-east1
     gcp_service_account_key: {{bbl_gcp_service_account_key}}
 ```
 #### Parameters:


### PR DESCRIPTION
This makes the examples in README copy-paste-able.